### PR TITLE
WIP: allow for user defined context

### DIFF
--- a/src/testlink/testlinkapigeneric.py
+++ b/src/testlink/testlinkapigeneric.py
@@ -65,8 +65,9 @@ class TestlinkAPIGeneric(object):
         encoding=args.get('encoding')
         verbose=args.get('verbose',0)
         allow_none=args.get('allow_none',0)
+        context=args.get('context',None)
         self.server = xmlrpclib.Server(server_url, transport, encoding,
-                                       verbose, allow_none)
+                                       verbose, allow_none, context=context)
         self.devKey = devKey
         self._server_url = server_url
         self._positionalArgNames = getMethodsWithPositionalArgs()


### PR DESCRIPTION
This merge will allow for a user defined context in the call to xmlrpclib.Server().

A use of this could look like:

```
import ssl
from testlink import TestlinkAPIGeneric, TestLinkHelper
my_test_link = TestLinkHelper(TESTLINK_API_PYTHON_SERVER_URL, TESTLINK_API_PYTHON_DEVKEY)\
    .connect(TestlinkAPIGeneric, context = ssl._create_unverified_context())
```