### PR TITLE
Allow to explicitly disable a http_proxy

### DIFF
--- a/src/testlink/testlinkhelper.py
+++ b/src/testlink/testlinkhelper.py
@@ -96,7 +96,7 @@ class TestLinkHelper(object):
         if self._devkey is None:
             self._devkey = os.getenv(self.ENVNAME_DEVKEY, self.DEFAULT_DEVKEY)
 
-        if not self._proxy:
+        if self._proxy is None:
             self._proxy =  os.getenv(self.ENVNAME_PROXY, self.DEFAULT_PROXY)
 
     def _createArgparser(self, usage):


### PR DESCRIPTION
The current code always sets the http proxy from the http_proxy variable
in the current environment. This makes testing difficult in setups where
testlink runs locally but the internet is only available via a proxy.

This allows the user to explicitly set proxy=False in the TestLinkHelper
instantiation.