### PR TITLE
Update testReporter createPlatform with new args (TL 1.9.20_fixed) #139

### DIFF
--- a/src/testlink/testreporter.py
+++ b/src/testlink/testreporter.py
@@ -202,7 +202,8 @@ class AddPlatformReporter(TestReporter):
             except TLResponseError as e:
                 if int(e.code) == 235:
                     self.tls.createPlatform(self.testprojectname, pn_kwarg,
-                                            notes=self.platformnotes)
+                                            notes=self.platformnotes,
+                                            platformondesign=True, platformonexecution=True)
                     self.tls.addPlatformToTestPlan(self.testplanid, pn_kwarg)
                     self._platformname_generated = True
                 else:


### PR DESCRIPTION
One of the example flow has not been updated to include the platformondesign platformonexecution flags.
Cause the testReporter to fail